### PR TITLE
Add run exports, pin libpciaccess to the version that has run exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,9 @@ source:
 
 build:
   skip: True  # [not linux]
-  number: 0
-  # For some reason, compiling with meson, the recommended way, doesn't
-  # correctly allow libva to find libdrm
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('libdrm', max_pin='x.x') }}
   script:
     - ./configure --prefix={{ PREFIX }}
     - make -j$(nproc) install
@@ -25,9 +25,8 @@ requirements:
     - {{ compiler('c') }}
     - pkg-config
   host:
-    - libpciaccess
-  run:
-    - libpciaccess
+    # build 0 of libpciaccess 0.14 didn't have the run_exports
+    - libpciaccess >=0.14=*_1
 
 test:
   commands:


### PR DESCRIPTION
@sodre they seem to break things on minor versions, especially the x.x.1 versions.
https://abi-laboratory.pro/index.php?view=timeline&l=libdrm

I hope I pinned libpciaccess correctly. Until it gets removed, I feel like that pinning should stay.


Hi @conda-forge/core,

Please move my package from main to broken on the conda-forge channel on anaconda.org
because:
I hadn't added run_exports to it before.

https://anaconda.org/conda-forge/libdrm/files


Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

